### PR TITLE
Fixing thread unsafe Lexer usage

### DIFF
--- a/src/net/ishchenko/idea/nginx/lexer/NginxSyntaxHighlighter.java
+++ b/src/net/ishchenko/idea/nginx/lexer/NginxSyntaxHighlighter.java
@@ -36,14 +36,10 @@ import java.util.Map;
  */
 public class NginxSyntaxHighlighter extends SyntaxHighlighterBase {
 
-    private Lexer lexer;
-
     private final TextAttributesKey[] BAD_CHARACTER_KEYS = new TextAttributesKey[]{HighlighterColors.BAD_CHARACTER};
     private final Map<IElementType, TextAttributesKey> colors = new HashMap<IElementType, TextAttributesKey>();
 
     public NginxSyntaxHighlighter() {
-
-        lexer = new FlexAdapter(new _NginxLexer((java.io.Reader) null));
 
         colors.put(NginxElementTypes.BAD_CHARACTER, HighlighterColors.BAD_CHARACTER);
         colors.put(NginxElementTypes.COMMENT, DefaultLanguageHighlighterColors.BLOCK_COMMENT);
@@ -56,7 +52,7 @@ public class NginxSyntaxHighlighter extends SyntaxHighlighterBase {
 
     @NotNull
     public Lexer getHighlightingLexer() {
-        return lexer;
+        return new FlexAdapter(new _NginxLexer((java.io.Reader) null));
     }
 
     @NotNull


### PR DESCRIPTION
Lexer is stated not thread safe, so if the lexer is singleton then there are multi-threading issues.  Like overwriting the lexer inner state from multiple threads and result may be array oob.

Discussion reference https://github.com/ishchenko/idea-nginx/issues/58